### PR TITLE
Manage team members (owners)

### DIFF
--- a/emails.auto.tfvars
+++ b/emails.auto.tfvars
@@ -1,0 +1,3 @@
+team_email_addresses = [
+  "alex@linfratech.co.uk"
+]


### PR DESCRIPTION
The free account doesn't actually let you create additional teams.
Importing the existing state was a pain, but I think I've got it figured
out correctly and this commit should result in zero changes.

Using `tfe_team_organization_member` is the preferred method to manage
team members and I ran into problems when trying out the simpler looking
`tfe_team_members` (it was going to remove api users).